### PR TITLE
Print email metadata on preview without body

### DIFF
--- a/lib/bamboo/plug/sent_email_viewer/index.html.eex
+++ b/lib/bamboo/plug/sent_email_viewer/index.html.eex
@@ -257,6 +257,11 @@
           <% else %>
             <h3 class="email-detail-body-label">No text body</h3>
           <% end %>
+
+          <%= unless @selected_email.html_body || @selected_email.text_body do %>
+            <h3 class="email-detail-body-label">Metadata</h3>
+            <pre><code><%= inspect(@selected_email, pretty: true) %></pre></code>
+          <% end %>
         </section>
       </section>
     </main>

--- a/test/lib/bamboo/plug/sent_email_viewer_plug_test.exs
+++ b/test/lib/bamboo/plug/sent_email_viewer_plug_test.exs
@@ -282,6 +282,19 @@ defmodule Bamboo.SentEmailViewerPlugTest do
     assert conn.resp_body =~ "Email not found"
   end
 
+  test "shows email metadata when there is no html or text body" do
+    email = normalize_and_push(:email, html_body: nil)
+    selected_email_id = SentEmail.all() |> Enum.at(0) |> SentEmail.get_id()
+    conn = conn(:get, "/sent_emails/foo/#{selected_email_id}")
+
+    conn = AppRouter.call(conn, nil)
+
+    assert conn.status == 200
+    assert {"content-type", "text/html; charset=utf-8"} in conn.resp_headers
+    assert conn.resp_body =~ "Metadata"
+    assert conn.resp_body =~ "#{inspect(email, pretty: true)}"
+  end
+
   defp newest_email do
     SentEmail.all() |> List.first()
   end


### PR DESCRIPTION
Why:

* In a setup where one uses a email service with transactional templates or any other mechanism where the system does not actually render the email content but instead triggers an external service to generate the emails, previewing sent emails in a development environment is pretty much useless since nothing is shown. Instead developers have to use the logs to try and parse the relevant email information.

This change addresses the issue by:

* Including the email information as metadata when the email has no body. This shows the data being sent to external service to generate the email, thus providing a way for developers to check the relevant values in a development environment.

![Screenshot 2024-05-04 at 00 02 12](https://github.com/coverflex-tech/bamboo/assets/1141870/63745764-02c2-4e6f-ac9c-010ef9c98829)
